### PR TITLE
status and statusText other than 200 and "OK"

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -183,6 +183,8 @@
                 root = doc.documentElement ? doc.documentElement : doc.body,
                 textarea = root.getElementsByTagName("textarea")[0],
                 type = textarea ? textarea.getAttribute("data-type") : null,
+                status = textarea ? textarea.getAttribute("data-status") : 200,
+                statusText = textarea ? textarea.getAttribute("data-statusText") : "OK",
                 content = {
                   html: root.innerHTML,
                   text: type ?
@@ -190,7 +192,7 @@
                     root ? (root.textContent || root.innerText) : null
                 };
               cleanUp();
-              completeCallback(200, "OK", content, type ?
+              completeCallback(status, statusText, content, type ?
                 ("Content-Type: " + type) :
                 null);
             });


### PR DESCRIPTION
Hi,

I extended the script to use optional data-status and data-statusText attributes on the respose textarea in order to return a status other than 200.

```
<textarea data-type="application/json" data-status="422" data-statusText="Unprocessable Entity">
  {"errors": …}
</textarea>
```

If not provided, status will default to 200 and "OK".

Use case:

Backbone.sync relies on the status returned by the xhr in order to decide, whether to use an error or success callback.

Laurens
