### PR TITLE
Made all textarea parameters optional

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -182,9 +182,9 @@
                 (this.contentDocument ? this.contentDocument : this.document),
                 root = doc.documentElement ? doc.documentElement : doc.body,
                 textarea = root.getElementsByTagName("textarea")[0],
-                type = textarea ? textarea.getAttribute("data-type") : null,
-                status = textarea ? textarea.getAttribute("data-status") : 200,
-                statusText = textarea ? textarea.getAttribute("data-statusText") : "OK",
+                type = textarea && textarea.getAttribute("data-type") || null,
+                status = textarea && textarea.getAttribute("data-status") || 200,
+                statusText = textarea && textarea.getAttribute("data-statusText") || "OK",
                 content = {
                   html: root.innerHTML,
                   text: type ?


### PR DESCRIPTION
I wanted to use the textarea workaround for setting response parameters. I found out that the plugin would only work correctly if all the data attributes were set. It would be better to use default values for those that are not set.

Now the example from the documentation actually works:

```
<textarea data-type="application/json">
  {"ok": false, "message": "Please only upload reasonably sized files."}
</textarea>
```

before we needed to set:

```
<textarea data-status="200" data-statusText="OK" data-type="application/json">
  {"ok": false, "message": "Please only upload reasonably sized files."}
</textarea>
```
