### PR TITLE
Fix parsererror in chrome.

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -189,7 +189,7 @@
                   html: root.innerHTML,
                   text: type ?
                     textarea.value :
-                    root ? (root.textContent || root.innerText) : null
+                    root ? (root.innerText || root.textContent) : null
                 };
               cleanUp();
               completeCallback(status, statusText, content, type ?


### PR DESCRIPTION
While IE doesn't support textContent and Firefox doesn't support innerHTML, Chrome supports both but doesn't handle the same each method.

I got a bug in Chrome due to Ripple extension that adds some javascript on top of the iframe content. 
Thus:
root.textContent will not escape the javascript
root.innerText will escape the javascript

So I suggest to prioritize innerText.
