### PR TITLE
Google chrome fix

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -192,7 +192,9 @@
                     root ? (root.textContent || root.innerText) : null
                 };
               // This fixes bug for google-chrome, some plugin accidentally appends html comment into json
-              content.text = content.text.replace(/^<!--.*?-->/g, '');
+              if(content.text){
+                content.text = content.text.replace(/^<!--.*?-->/g, '');
+              }
               cleanUp();
               completeCallback(status, statusText, content, type ?
                 ("Content-Type: " + type) :


### PR DESCRIPTION
Some google-chrome plugin appends html comment before json so plugin didn't work for me.
Comment appended is <!-- script injected by Request Maker -->
After fix plugin was tested with firefox. 
Code shows how I've fixed problem but perhaps it is not the best way since similar problems with other injected text are possible.
