### PR TITLE
Fix cmlenz#21 - Wait for load before removal.

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -118,7 +118,8 @@
         return files.get(idx);
       });
       form.remove();
-      iframe.attr("src", "javascript:false;").remove();
+      iframe.bind("load", function() { iframe.remove(); });
+      iframe.attr("src", "javascript:false;");
     }
 
     // Remove "iframe" from the data types list so that further processing is


### PR DESCRIPTION
I am also experiencing the issue from cmlenz#21 wherein Chrome reports the request as cancelled despite it being a success.  Waiting for the `load` event before removal fixes the issue handily.  :)
