### PR TITLE
Restore file inputs by re-enabling.

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -114,9 +114,7 @@
     // and should revert all changes made to the page to enable the
     // submission via this transport.
     function cleanUp() {
-      markers.replaceWith(function(idx) {
-        return files.get(idx);
-      });
+      markers.prop('disabled', false);
       form.remove();
       iframe.bind("load", function() { iframe.remove(); });
       iframe.attr("src", "javascript:false;");


### PR DESCRIPTION
The `cleanUp` function says that it should revert all changes made by the iframe-transport, but the only changes it makes to file inputs is that it disables them on [this line](https://github.com/JangoSteve/jquery-iframe-transport/blob/00cf919e153dbd1a4f59c6ef91f310383ec7ade0/jquery.iframe-transport.js#L159).

I can't really figure out what this `replaceWith` is supposed to be accomplishing, but for me after a form is submitted with this, the file inputs disappear, leaving only their labels with no input next to them, making the form unusable.

This pull request actually restores the file inputs to the way they were by just re-enabling them.
