### PR TITLE
Send dataTypes in post, useful for Rails and similar frameworks.

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -108,7 +108,8 @@
         iframe = null,
         name = "iframe-" + $.now(),
         files = $(options.files).filter(":file:enabled"),
-        markers = null;
+        markers = null,
+        accepts;
 
     // This function gets called after a successful submission or an abortion
     // and should revert all changes made to the page to enable the
@@ -152,6 +153,15 @@
       // through this transport.
       $("<input type='hidden' value='IFrame' name='X-Requested-With' />").
         appendTo(form);
+
+      // Borrowed straight from the JQuery source
+      // Provides a way of specifying the accepted data type similar to HTTP_ACCEPTS
+      accepts = options.dataTypes[ 0 ] && options.accepts[ options.dataTypes[0] ] ?
+        options.accepts[ options.dataTypes[0] ] + ( options.dataTypes[ 0 ] !== "*" ? ", */*; q=0.01" : "" ) :
+        options.accepts[ "*" ]
+
+      $("<input type='hidden' name='X-Http-Accept'>")
+        .attr("value", accepts).appendTo(form);
 
       // Move the file fields into the hidden form, but first remember their
       // original locations in the document by replacing them with disabled


### PR DESCRIPTION
When we have forms that use a jQuery `$.ajax dataType` other than `text/html`, when it's submitted via the iframe-transport, it always gets overwritten as just a `text/html` request.

Of course, that's to be expected since it's being submitted as a normal form submission (not actually AJAX), but we need to preserve the original intended data-type and send it to the server so that we can handle the response appropriately.
