### PR TITLE
Various fixes from heavy use on wikispaces.com

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -116,10 +116,7 @@
     // and should revert all changes made to the page to enable the
     // submission via this transport.
     function cleanUp() {
-      files.each(function (i, file) {
-        var $file = $(file);
-        $file.data("clone").replaceWith($file);
-      });
+      markers.prop("disabled", false);
       form.remove();
       iframe.one("load", function() { iframe.remove(); });
       iframe.attr("src", "javascript:false;");
@@ -178,10 +175,7 @@
       // clones. This should also avoid introducing unwanted changes to the
       // page layout during submission.
       markers = files.after(function(idx) {
-        var $this = $(this),
-            $clone = $this.clone().prop("disabled", true);
-        $this.data("clone", $clone);
-        return $clone;
+        return $(this).clone().prop("disabled", true);
       }).next();
       files.appendTo(form);
 

--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -116,7 +116,7 @@
     // and should revert all changes made to the page to enable the
     // submission via this transport.
     function cleanUp() {
-      files.each(function(i, file) {
+      files.each(function (i, file) {
         var $file = $(file);
         $file.data("clone").replaceWith($file);
       });


### PR DESCRIPTION
We use this transport for almost all requests from our front-end.  These are the changes we've accumulated over time.

* prefilter/transport: switch type so jQuery doesn't add to the url
* prefilter: restore data incase processData wasn't false
* add unique id to avoid duplicate iframes in the same second.
* use empty jQuery objects instead of null to guard against NPEs
* alter cleanUp to be more useful, use it as abort directly.
* Always add data, even if there aren't files
* Allow elements to be passed in data
* add cache-busting param if need be