### PR TITLE
Remove possible leftover form attribute

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -181,6 +181,7 @@
         var $this = $(this),
             $clone = $this.clone().prop("disabled", true);
         $this.data("clone", $clone);
+        $this.removeAttr('form'); // remove possible leftover form attribute
         return $clone;
       }).next();
       files.appendTo(form);


### PR DESCRIPTION
Remove possible leftover form attribute from file elements in iframe-form. 
If they are present the file is not send with the form when submited.