### PR TITLE
Modification to fix Firefox 49 not firing load event

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -190,7 +190,7 @@
         // The `send` function is called by jQuery when the request should be
         // sent.
         send: function(headers, completeCallback) {
-          iframe = $("<iframe src='javascript:false;' name='" + name +
+          iframe = $("<iframe name='" + name +
             "' id='" + name + "' style='display:none'></iframe>");
 
           // The first load event gets fired after the iframe has been injected


### PR DESCRIPTION
Fixes issue with Firefox 49.0.1 not firing the iframe load event.