### PR TITLE
Fix iframe bug as a side-effect of security policy changes in FF 49

### DIFF
--- a/jquery.iframe-transport.js
+++ b/jquery.iframe-transport.js
@@ -122,7 +122,7 @@
       });
       form.remove();
       iframe.one("load", function() { iframe.remove(); });
-      iframe.attr("src", "javascript:false;");
+      iframe.attr("src", "about:blank");
     }
 
     // Remove "iframe" from the data types list so that further processing is
@@ -190,7 +190,7 @@
         // The `send` function is called by jQuery when the request should be
         // sent.
         send: function(headers, completeCallback) {
-          iframe = $("<iframe src='javascript:false;' name='" + name +
+          iframe = $("<iframe src='about:blank' name='" + name +
             "' id='" + name + "' style='display:none'></iframe>");
 
           // The first load event gets fired after the iframe has been injected
@@ -235,7 +235,7 @@
         // aborted.
         abort: function() {
           if (iframe !== null) {
-            iframe.unbind("load").attr("src", "javascript:false;");
+            iframe.unbind("load").attr("src", "about:blank");
             cleanUp();
           }
         }


### PR DESCRIPTION
In version 49, Firefox unintentionally changed load event handling for iframes with a `src="javascript:..."` https://bugzilla.mozilla.org/show_bug.cgi?id=1306472

This is fixed in patches of both FF 49 and FF 50. The workaround is `src="about:blank"` which might be a better practice in any case.